### PR TITLE
Support for md ref links, others

### DIFF
--- a/src/inputs/git-diff.ts
+++ b/src/inputs/git-diff.ts
@@ -66,7 +66,7 @@ const getFileContentEntries: (
     /^diff --git.* b\/(.*)\n(?:.*\n){4}/gm
   );
 
-  const processedOutputs = [];
+  const processedOutputs: FileContentEntry[] = [];
   for (let i = 1; i < splitPatchText.length; i += 2) {
     const filePath = splitPatchText[i];
     if (
@@ -74,7 +74,8 @@ const getFileContentEntries: (
     ) {
       const content = splitPatchText[i + 1]
         .split("\n")
-        .filter((line) => line.startsWith("+"));
+        .filter((line) => line.startsWith("+"))
+        .join("\n");
 
       if (content.length > 0) {
         processedOutputs.push({

--- a/src/inputs/git-diff.ts
+++ b/src/inputs/git-diff.ts
@@ -75,6 +75,7 @@ const getFileContentEntries: (
       const content = splitPatchText[i + 1]
         .split("\n")
         .filter((line) => line.startsWith("+"))
+        .map((line) => line.slice(1))
         .join("\n");
 
       if (content.length > 0) {

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -1,11 +1,12 @@
 import scrapeLinks from "./scrapeLinks";
 
-const testMarkdownString = `
-This is a Markdown example with [a link to google](https://www.google.com) and [one with a subdirectory](https://www.google.com/nested/page.html)
+const markdownString = `
+Markdown example with a [link to Google](https://www.google.com), one [with a URL path](https://www.google.com/nested/page.html), and others:
 
-and [another to reddit](www.reddit.com) and [a third to Twitter](facebook.com)
+- One [to reddit](www.reddit.com)
+- A fourth [to Facebook](facebook.com) (incomplete URLs)
 
-as well as some blank lines
+There's also some blank lines, misc. text, and <span>HTML</span> code.
 `;
 
 const plaintextString = `
@@ -13,8 +14,15 @@ This string is plaintext, with links like https://www.google.com and https://www
 
 I can scrape "https://reddit.com/r/subreddit" and (https://facebook.com) as well!
 
-The new regex can pull www.youtube.com too!? unfortunately, gmail.com is just too vague.
+The new regex can pull www.youtube.com too!? Unfortunately, gmail.com is just too vague.
 `;
+
+const markdownTestResult = [
+  "https://www.google.com",
+  "https://www.google.com/nested/page.html",
+  "www.reddit.com",
+  "facebook.com",
+];
 
 const plaintextTestResult = [
   "https://www.google.com",
@@ -24,24 +32,17 @@ const plaintextTestResult = [
   "www.youtube.com",
 ];
 
-const markdownTestResult = [
-  "https://www.google.com",
-  "https://www.google.com/nested/page.html",
-  "www.reddit.com",
-  "facebook.com",
-];
-
 test("It scrapes from the markdown test string", () => {
   expect(
     scrapeLinks({
       filePath: "test.md",
-      content: testMarkdownString,
+      content: markdownString,
     })
   ).toEqual(markdownTestResult);
 });
 
 test("It scrapes from the markdown test split by newlines", () => {
-  const splitTest = testMarkdownString.split("\n");
+  const splitTest = markdownString.split("\n");
   expect(
     scrapeLinks({
       filePath: "test.md",

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -12,9 +12,10 @@ There's also some blank lines, misc. text, and <span>HTML</span> code.
 const plaintextString = `
 This string is plaintext, with links like https://www.google.com and https://www.google.com/nested/page.html
 
-I can scrape "https://reddit.com/r/subreddit" and (https://facebook.com) as well!
+I can scrape "https://reddit.com/r/subreddit" and (https://facebook.com) as well! The new regex can pull www.youtube.com too!?
 
-The new regex can pull www.youtube.com too!? Unfortunately, gmail.com is just too vague.
+TODO: Unfortunately, gmail.com is just too vague.
+TODO: Ending in a period won't work well either, e.g. www.something.com.
 `;
 
 const markdownTestResult = [
@@ -30,6 +31,7 @@ const plaintextTestResult = [
   "https://reddit.com/r/subreddit",
   "https://facebook.com",
   "www.youtube.com",
+  "www.something.com.",
 ];
 
 test("It scrapes from the markdown test string", () => {

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -54,16 +54,6 @@ test("It scrapes from the markdown test string", () => {
   ).toEqual(markdownTestResult);
 });
 
-test("It scrapes from the markdown test split by newlines", () => {
-  const splitTest = markdownString.split("\n");
-  expect(
-    scrapeLinks({
-      filePath: "test.md",
-      content: splitTest,
-    })
-  ).toEqual(markdownTestResult);
-});
-
 test("It scrapes absolute links from unrecognized extensions", () => {
   expect(
     scrapeLinks({

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -5,6 +5,13 @@ Markdown example with a [link to Google](https://www.google.com), one [with a UR
 
 - One [to reddit](www.reddit.com)
 - A fourth [to Facebook](facebook.com) (incomplete URLs)
+- Finally a few [ref] [links][links] [here][link-here]
+
+[ref]: https://www.ref.com
+[links]:
+  www.links.in/newline
+[link-here]:
+  /just/a/path
 
 There's also some blank lines, misc. text, and <span>HTML</span> code.
 `;
@@ -23,6 +30,9 @@ const markdownTestResult = [
   "https://www.google.com/nested/page.html",
   "www.reddit.com",
   "facebook.com",
+  "https://www.ref.com",
+  "www.links.in/newline",
+  "/just/a/path",
 ];
 
 const plaintextTestResult = [

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -1,11 +1,12 @@
 import scrapeLinks from "./scrapeLinks";
 
 const markdownString = `
-Markdown example with a [link to Google](https://www.google.com), one [with a URL path](https://www.google.com/nested/page.html), and others:
+Markdown sample with a [link to Google](https://www.google.com), one [with a URL path](https://www.google.com/nested/page.html), and others:
 
 - One [to reddit](www.reddit.com)
 - A fourth [to Facebook](facebook.com) (incomplete URLs)
 - Finally a few [ref] [links][links] [here][link-here]
+- BTW it shouldn't plain links like http://www.this.com or that.com shouldn't get picked up.
 
 [ref]: https://www.ref.com
 [links]:

--- a/src/scrapeLinks.ts
+++ b/src/scrapeLinks.ts
@@ -29,7 +29,7 @@ const scrapeFromString: (filePath: string, content: string) => string[] = (
       );
       const mdRefLinks = regexMap(
         content,
-        /\[.*?\]:\s*\n?\s*(.*)/gm,
+        /\[.*\]:\s*\n?\s*(.*)/gm,
         (x) => x[2] || x[1]
       );
       const hrefLinks = regexMap(content, /href="(.*?)"/gm);

--- a/src/scrapeLinks.ts
+++ b/src/scrapeLinks.ts
@@ -27,8 +27,13 @@ const scrapeFromString: (filePath: string, content: string) => string[] = (
         /\[.*?\]\((?:<((?:\(.*?\)|.)*?)>|((?:\(.*?\)|.)*?))(?: ["'].*?["'])?\)/gm,
         (x) => x[2] || x[1]
       );
+      const mdRefLinks = regexMap(
+        content,
+        /\[.*?\]:\s*\n?\s*(.*)/gm,
+        (x) => x[2] || x[1]
+      );
       const hrefLinks = regexMap(content, /href="(.*?)"/gm);
-      const links = mdLinks.concat(hrefLinks);
+      const links = mdLinks.concat(mdRefLinks).concat(hrefLinks);
       return links
         ? links
             .filter(Boolean)

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,7 @@ export interface StringFilter {
 }
 
 export interface FileContentEntry extends FileEntry {
-  content:
-    | string
-    | string[]
-    | ((filePath?: string) => string | string[] | Promise<string | string[]>);
+  content: string | ((filePath?: string) => string | Promise<string>);
 }
 
 export interface FileChecksEntry extends FileEntry {


### PR DESCRIPTION
Would close #4

Also adds support for links in the special dvc.org element `external-link` (rel. https://github.com/iterative/dvc.org/pull/2567#pullrequestreview-687762528)

- [ ] Continue https://github.com/iterative/dvc.org/pull/2534 when this is done.