### PR TITLE
fix execution

### DIFF
--- a/webpack/cli.js
+++ b/webpack/cli.js
@@ -7,7 +7,7 @@ const cliConfig = {
   entry: "./cli.ts",
   plugins: [
     new webpack.BannerPlugin({
-      banner: "#!/bin/node",
+      banner: "#!/usr/bin/env node",
       entryOnly: true,
       raw: true,
     }),


### PR DESCRIPTION
looking at `node_modules/.bin/*`, the standard practice is to use `#!/usr/bin/env node` for this reason.