### PR TITLE
Add user agent option with new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ The minimum amount of time in ms to wait before two requests on one domain. Defa
 
 The maximum amount of requests allowed on each hostname at one time. Defaults to 1.
 
+### userAgent: string
+
+When specified, will use this string as the `user-agent` header in link check requests.
+
+Defaults to `Mozilla/5.0 (compatible; Iterative/link-check; +https://github.com/iterative/link-check)`
+
 ### linkOptions: Map<string, options>
 
 This object determines settings that will be applied for each hostname. The keys

--- a/src/checkLink.ts
+++ b/src/checkLink.ts
@@ -27,10 +27,20 @@ const bottleneckedFetch: (
   url: URL,
   fetchOptions: { method: string },
   options: LinkCheckOptions
-) => Promise<Response> = async (url, fetchOptions, options) =>
-  getBottleneck(url.hostname, options).schedule(() =>
-    fetch(url.href, fetchOptions)
+) => Promise<Response> = async (url, fetchOptions, options) => {
+  const {
+    userAgent = "Mozilla/5.0 (compatible; Iterative/link-check; +https://github.com/iterative/link-check)",
+  } = options;
+
+  return getBottleneck(url.hostname, options).schedule(() =>
+    fetch(url.href, {
+      ...fetchOptions,
+      headers: {
+        "user-agent": userAgent,
+      },
+    })
   );
+};
 
 const fetchWithRetries = async (
   url: URL,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,7 @@ const optionsFromFlags: () => Promise<LinkCheckOptions> = async () => {
       "Add a micromatch pattern used to exclude files to scrape links from",
       collect
     )
+    .option("-ua, --userAgent <string>", "Use a custom user agent for requests")
     .on("--help", () => {
       console.log(
         "\nTo specify multiple patterns, use the relevant flag multiple times."
@@ -80,6 +81,7 @@ const optionsFromFlags: () => Promise<LinkCheckOptions> = async () => {
     dryRun = unusedPatternsOnly,
     failsOnly,
     verbose,
+    userAgent,
   } = program;
 
   const argsOptions = {
@@ -93,6 +95,7 @@ const optionsFromFlags: () => Promise<LinkCheckOptions> = async () => {
     verbose,
     dryRun,
     failsOnly,
+    userAgent,
   };
 
   const fileOptions = await parseFile(configFile);

--- a/src/github-action/action.yml
+++ b/src/github-action/action.yml
@@ -62,6 +62,10 @@ inputs:
       A string or JSON array of micromatch patterns to blacklist files.
       Takes priority over inclusion patterns.
     required: false
+  userAgent:
+    description: >-
+      When specified, will use this string as the `user-agent` header in link check requests.
+      Defaults to `Mozilla/5.0 (compatible; Iterative/link-check; +https://github.com/iterative/link-check)`
   output:
     description: >-
       A string or JSON array of output methods to use. "consoleLog" and

--- a/src/github-action/index.ts
+++ b/src/github-action/index.ts
@@ -62,6 +62,7 @@ async function optionsFromCoreInputs() {
     "fileIncludePatterns",
     "fileExcludePatternFile",
     "fileExcludePatterns",
+    "userAgent",
     "output",
     "failsOnly",
     "verbose",

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface LinkCheckOptions extends CoreLinkCheckOptions {
   output?: string[];
   failsOnly?: boolean;
   origin?: string;
+  userAgent?: string;
 }
 
 export interface UnresolvedLinkCheckOptions extends CoreLinkCheckOptions {


### PR DESCRIPTION
Quick change to allow for a custom user agent to be specified, should help get around medium links which hate `node-fetch`'s default agent.