### PR TITLE
Get default branch from deployment event

### DIFF
--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -6,7 +6,7 @@ on:
         type: "string"
         required: false
         description: "The branch to compare against when finding new links to check"
-        default: "${{ github.event.deployment.payload.web_url }}"
+        default: "${{ github.event.repository.default_branch }}"
 jobs:
   run:
     name: Run

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -2,11 +2,11 @@ name: Check new links against deployment
 on:
   workflow_call:
     inputs:
-      main:
+      branch:
         type: "string"
         required: false
-        description: "The main branch of this repository"
-        default: "main"
+        description: "The branch to compare against when finding new links to check"
+        default: "${{ github.event.deployment.payload.web_url }}"
 jobs:
   run:
     name: Run
@@ -24,7 +24,8 @@ jobs:
           set +e
           body="$(
             npx repo-link-check \
-            -d ${{ inputs.main }} -c config/link-check/config.yml \
+            -d ${{ inputs.branch }} \
+            -c config/link-check/config.yml \
             -r ${{ github.event.deployment.payload.web_url }}
           )"
           body="${body//'%'/'%25'}"


### PR DESCRIPTION
This PR utilizes the `default_branch` given to us by GitHub to populate the `branch` (previously `main`) field when getting diffs.

The ability to override the branch is kept because it was easy and could be useful in some cases, but in most cases users won't need it.

Test branch at https://github.com/iterative/cml.dev/pull/287