### PR TITLE
Fix link-check-all syntax

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -3,6 +3,7 @@ on:
   workflow_call:
     inputs:
       config:
+        type: 'string'
         description: 'The path to the link-check config file'
         default: 'config/link-check/config.yml'
 jobs:


### PR DESCRIPTION
Missed a required value on the `link-check-all` workflow, only noticed it once a run failed.