### PR TITLE
Add failsOnly options that defaults to true

### DIFF
--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -12,6 +12,11 @@ on:
         required: false
         description: "If true, only reports failed links"
         default: true
+      outputFile:
+        type: "string"
+        required: false
+        description: "The file the link check report will be written to before publishing"
+        default: "link-check-report.md"
 jobs:
   run:
     name: Run
@@ -23,43 +28,20 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: iterative/setup-cml@v1
+      - run: echo "# Link Check Report" > ${{ inputs.outputFile }}
       - name: Run Link Check
         id: check
+        continue-on-error: true
         run: |
-          set +e
-          body="$(
-            npx repo-link-check \
+          npx repo-link-check \
             ${{ inputs.failsOnly && '-f' || '' }} \
             -d ${{ inputs.branch }} \
             -c config/link-check/config.yml \
-            -r ${{ github.event.deployment.payload.web_url }}
-          )"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=report::$body"
-          exit 0
-
-      - name: Find Current Pull Request
-        id: findPr
-        uses: jwalton/gh-find-current-pr@v1.3.0
-
-      - name: Find Existing Link Check Report Comment
-        uses: peter-evans/find-comment@v2
-        id: findComment
-        continue-on-error: true
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <h1 id="link-check">Link Check Report</h1>
+            -r ${{ github.event.deployment.payload.web_url }} \
+            >> ${{ inputs.outputFile }}
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-id: ${{ steps.findComment.outputs.comment-id }}
-          body: |
-            <h1 id="link-check">Link Check Report</h1>
-
-            ${{ steps.check.outputs.report }}
-          edit-mode: replace
+        run: cml send-comment --pr --update ${{ inputs.outputFile }}
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -7,6 +7,11 @@ on:
         required: false
         description: "The branch to compare against when finding new links to check"
         default: "${{ github.event.repository.default_branch }}"
+      failsOnly:
+        type: "boolean"
+        required: false
+        description: "If true, only reports failed links"
+        default: true
 jobs:
   run:
     name: Run
@@ -24,6 +29,7 @@ jobs:
           set +e
           body="$(
             npx repo-link-check \
+            ${{ inputs.failsOnly && '-f' || '' }} \
             -d ${{ inputs.branch }} \
             -c config/link-check/config.yml \
             -r ${{ github.event.deployment.payload.web_url }}


### PR DESCRIPTION
This PR adds an option to the deployment_status reusable link check action that enables `failsOnly`, only writing failing links to the report.

live test on https://github.com/iterative/mlem.ai/pull/154

![image](https://user-images.githubusercontent.com/9111807/184968143-21ec5f78-9785-4eaf-ae62-d701507c86bb.png)