### PR TITLE
Use cml-based report workflow

### DIFF
--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -23,43 +23,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: iterative/setup-cml@v1
       - name: Run Link Check
         id: check
         run: |
-          set +e
-          body="$(
-            npx repo-link-check \
+          npx repo-link-check \
             ${{ inputs.failsOnly && '-f' || '' }} \
             -d ${{ inputs.branch }} \
             -c config/link-check/config.yml \
-            -r ${{ github.event.deployment.payload.web_url }}
-          )"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=report::$body"
-          exit 0
-
-      - name: Find Current Pull Request
-        id: findPr
-        uses: jwalton/gh-find-current-pr@v1.3.0
-
-      - name: Find Existing Link Check Report Comment
-        uses: peter-evans/find-comment@v2
-        id: findComment
-        continue-on-error: true
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <h1 id="link-check">Link Check Report</h1>
+            -r ${{ github.event.deployment.payload.web_url }} \
+            > output.md
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ steps.findPr.outputs.pr }}
-          comment-id: ${{ steps.findComment.outputs.comment-id }}
-          body: |
-            <h1 id="link-check">Link Check Report</h1>
-
-            ${{ steps.check.outputs.report }}
-          edit-mode: replace
+        run: cml send-comment --update output.md

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -12,6 +12,11 @@ on:
         required: false
         description: "If true, only reports failed links"
         default: true
+      outputFile:
+        type: "string"
+        required: false
+        description: "The file the link check report will be written to before publishing"
+        default: "link-check-report.md"
 jobs:
   run:
     name: Run
@@ -24,6 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: iterative/setup-cml@v1
+      - run: echo "# Link Check Report" > ${{ inputs.outputFile }}
       - name: Run Link Check
         id: check
         continue-on-error: true
@@ -33,9 +39,9 @@ jobs:
             -d ${{ inputs.branch }} \
             -c config/link-check/config.yml \
             -r ${{ github.event.deployment.payload.web_url }} \
-            > output.md
+            > ${{ inputs.outputFile }}
 
       - name: Create or update comment
-        run: cml send-comment --pr --update output.md
+        run: cml send-comment --pr --update ${{ inputs.outputFile }}
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -36,6 +36,6 @@ jobs:
             > output.md
 
       - name: Create or update comment
-        run: cml send-comment --update output.md
+        run: cml send-comment --pr --update output.md
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -39,7 +39,7 @@ jobs:
             -d ${{ inputs.branch }} \
             -c config/link-check/config.yml \
             -r ${{ github.event.deployment.payload.web_url }} \
-            > ${{ inputs.outputFile }}
+            >> ${{ inputs.outputFile }}
 
       - name: Create or update comment
         run: cml send-comment --pr --update ${{ inputs.outputFile }}

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -37,3 +37,5 @@ jobs:
 
       - name: Create or update comment
         run: cml send-comment --update output.md
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check-deployment-status.yml
+++ b/.github/workflows/link-check-deployment-status.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: iterative/setup-cml@v1
       - name: Run Link Check
         id: check
+        continue-on-error: true
         run: |
           npx repo-link-check \
             ${{ inputs.failsOnly && '-f' || '' }} \


### PR DESCRIPTION
This PR uses CML to report the results from link check in the `deployment-status` reusable workflow!

See a live test at https://github.com/iterative/mlem.ai/pull/140

Might invalidate [this section of the CML docs?](https://cml.dev/doc/ref/send-comment#github)