### PR TITLE
Allow single new line for link with : 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-link-check",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A multi-target library for ensuring all links in a file are alive",
   "main": "index.js",
   "author": "RMP",

--- a/src/scrapeLinks.test.js
+++ b/src/scrapeLinks.test.js
@@ -8,6 +8,10 @@ Markdown sample with a [link to Google](https://www.google.com), one [with a URL
 - Finally a few [ref] [links][links] [here][link-here]
 - BTW it shouldn't plain links like http://www.this.com or that.com shouldn't get picked up.
 
+this is a test [ref]:
+
+https://www.ref.com
+
 [ref]: https://www.ref.com
 [links]:
   www.links.in/newline

--- a/src/scrapeLinks.ts
+++ b/src/scrapeLinks.ts
@@ -29,7 +29,7 @@ const scrapeFromString: (filePath: string, content: string) => string[] = (
       )
       const mdRefLinks = regexMap(
         content,
-        /\[.*\]:\s*\n?\s*(.*)/gm,
+        /\[.*\]:[^\S\r\n]*\n?[^\S\r\n]*(.*)/gm,
         x => x[2] || x[1]
       )
       const hrefLinks = regexMap(content, /href="(.*?)"/gm)


### PR DESCRIPTION
Updated regex to allow only a single new line to support 
```
[config composition]:
  https://hydra.cc/docs/tutorials/basic/your_first_app/composition/
```
but it will skip if there are multiple new lines eg:
````
[defaults list]:

```yaml
````

Test: 
I added the following snippet and ran the tests. It looks fine.
```
this is a test [ref]:

https://www.ref.com/
```
<img width="456" alt="Screen Shot 2022-10-13 at 15 52 26" src="https://user-images.githubusercontent.com/20840228/195568677-847f264a-3b03-4963-96ae-74ff09aa9acc.png">

Fixes #28 